### PR TITLE
Setup mifos x on local system

### DIFF
--- a/mifosx/docker-compose.yml
+++ b/mifosx/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+services:
+  mysql:
+    image: mysql:5.7
+    container_name: mifos-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+    command: ["--character-set-server=utf8", "--collation-server=utf8_general_ci"]
+    ports:
+      - "3306:3306"
+    volumes:
+      - dbdata:/var/lib/mysql
+      - ./initdb:/docker-entrypoint-initdb.d
+  fineract:
+    image: openmf/fineract:1.12.1
+    container_name: fineract-provider
+    depends_on:
+      - mysql
+    environment:
+      - FINERACT_DEFAULT_TENANTDB=mifostenant-default
+      - FINERACT_DEFAULT_TENANTID=default
+      - FINERACT_HIKARI_DRIVER_SOURCE=com.mysql.jdbc.Driver
+      - FINERACT_HIKARI_JDBC_URL=jdbc:mysql://mysql:3306/mifosplatform-tenants
+      - FINERACT_HIKARI_JDBC_USERNAME=root
+      - FINERACT_HIKARI_JDBC_PASSWORD=mysql
+      - FINERACT_SERVER_PORT=8443
+    ports:
+      - "8443:8443"
+    restart: unless-stopped
+  community_app:
+    image: openmf/community-app:latest
+    container_name: mifos-community-app
+    depends_on:
+      - fineract
+    environment:
+      - FINERACT_API_URL=https://localhost:8443/fineract-provider/api/v1
+    ports:
+      - "3000:80"
+    restart: unless-stopped
+volumes:
+  dbdata:

--- a/mifosx/initdb/00-create-dbs.sql
+++ b/mifosx/initdb/00-create-dbs.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE IF NOT EXISTS `mifosplatform-tenants` CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE DATABASE IF NOT EXISTS `mifostenant-default` CHARACTER SET utf8 COLLATE utf8_general_ci;

--- a/mifosx/initdb/10-tenants.sql
+++ b/mifosx/initdb/10-tenants.sql
@@ -1,0 +1,15 @@
+USE `mifosplatform-tenants`;
+CREATE TABLE IF NOT EXISTS `mifos_tenants` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(100) NOT NULL,
+  `name` varchar(100) NOT NULL,
+  `description` varchar(500) DEFAULT NULL,
+  `schema_name` varchar(100) NOT NULL,
+  `timezone_id` varchar(100) NOT NULL DEFAULT 'UTC',
+  `created_on_utc` datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_mifos_tenants_identifier` (`identifier`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO `mifos_tenants` (`identifier`, `name`, `description`, `schema_name`, `timezone_id`) 
+  VALUES ('default', 'Default Tenant', 'Default tenant for demo', 'mifostenant-default', 'UTC')
+  ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), schema_name=VALUES(schema_name), timezone_id=VALUES(timezone_id);

--- a/mifosx/initdb/20-default-schema.sql
+++ b/mifosx/initdb/20-default-schema.sql
@@ -1,0 +1,2 @@
+USE `mifostenant-default`;
+-- Placeholder: Fineract will auto-migrate schema on startup. Ensure DB exists.


### PR DESCRIPTION
## Description

Introduces a Docker Compose setup for Apache Fineract (Mifos X backend) and the Community App. This change provides a modern, reproducible, and isolated installation method for Linux users, simplifying deployment and avoiding manual dependency management compared to traditional installation guides.

## Related issues and discussion

#

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c505795-fef7-4f40-b9c8-b41b5116ccae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c505795-fef7-4f40-b9c8-b41b5116ccae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

